### PR TITLE
Add support for PrimeVue passthrough prop

### DIFF
--- a/src/formkit/PrimeCalendar.vue
+++ b/src/formkit/PrimeCalendar.vue
@@ -69,6 +69,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :append-to="attrs.appendTo ?? 'body'"
       :panel-style="attrs.panelStyle"
       :panel-class="attrs.panelClass"
+      :pt="attrs.pt"
       @date-select="handleSelect"
       @input="handleInput"
     />

--- a/src/formkit/PrimeCheckbox.vue
+++ b/src/formkit/PrimeCheckbox.vue
@@ -29,6 +29,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :binary="attrs.binary ?? true"
       :true-value="attrs.trueValue ?? undefined"
       :false-value="attrs.falseValue ?? undefined"
+      :pt="attrs.pt"
       @input="handleInput"
     />
     <span v-if="context.attrs.labelRight" class="formkit-prime-right">{{ context.attrs.labelRight }}</span>

--- a/src/formkit/PrimeChips.vue
+++ b/src/formkit/PrimeChips.vue
@@ -29,6 +29,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :max="attrs.max ?? undefined"
       :placeholder="attrs.placeholder"
       :separator="attrs.separator"
+      :pt="attrs.pt"
       @add="handleInput"
       @remove="handleInput"
     />

--- a/src/formkit/PrimeColorPicker.vue
+++ b/src/formkit/PrimeColorPicker.vue
@@ -25,6 +25,7 @@ function handleChange(e: any) {
       :default-color="attrs.defaultColor ?? 'ff0000'"
       :inline="attrs.inline ?? false"
       :format="attrs.format"
+      :pt="attrs.pt"
       @change="handleChange"
     />
   </div>

--- a/src/formkit/PrimeDropdown.vue
+++ b/src/formkit/PrimeDropdown.vue
@@ -33,6 +33,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :placeholder="attrs.placeholder"
       :filter="attrs.filter ?? false"
       :show-clear="attrs.showClear ?? false"
+      :pt="attrs.pt"
       @change="handleInput"
       @blur="handleBlur"
     />

--- a/src/formkit/PrimeEditor.vue
+++ b/src/formkit/PrimeEditor.vue
@@ -35,6 +35,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :placeholder="attrs.placeholder"
       :formats="attrs.formats"
       :modules="attrs.modules"
+      :pt="attrs.pt"
       @text-change="handleInput"
       @selection-change="handleSelection"
     />

--- a/src/formkit/PrimeInputMask.vue
+++ b/src/formkit/PrimeInputMask.vue
@@ -30,6 +30,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :slot-char="attrs.slotChar ?? '_'"
       :auto-clear="attrs.autoClear ?? true"
       :unmask="attrs.unmask ?? false"
+      :pt="attrs.pt"
       @blur="handleInput"
     />
   </div>

--- a/src/formkit/PrimeInputNumber.vue
+++ b/src/formkit/PrimeInputNumber.vue
@@ -40,6 +40,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :show-buttons="attrs.showButtons ?? undefined"
       :button-layout="attrs.buttonLayout ?? 'stacked'"
       :step="attrs.step ?? undefined"
+      :pt="attrs.pt"
       @input="handleInput"
       @blur="handleBlur"
     />

--- a/src/formkit/PrimeInputSwitch.vue
+++ b/src/formkit/PrimeInputSwitch.vue
@@ -27,6 +27,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :aria-labelledby="attrs.ariaLabelledby"
       :true-value="attrs.trueValue ?? undefined"
       :false-value="attrs.falseValue ?? undefined"
+      :pt="attrs.pt"
       @input="handleInput"
     />
     <span v-if="context.attrs.labelRight" class="formkit-prime-right">{{ context.attrs.labelRight }}</span>

--- a/src/formkit/PrimeInputText.vue
+++ b/src/formkit/PrimeInputText.vue
@@ -50,6 +50,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
         :aria-label="attrs.ariaLabel"
         :aria-labelledby="attrs.ariaLabelledby"
         :placeholder="attrs.placeholder"
+        :pt="attrs.pt"
         @input="handleInput"
         @blur="handleBlur"
       />

--- a/src/formkit/PrimeKnob.vue
+++ b/src/formkit/PrimeKnob.vue
@@ -36,6 +36,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :range-color="attrs.rangeColor ?? undefined"
       :text-color="attrs.textColor ?? undefined"
       :value-template="attrs.valueTemplate ?? undefined"
+      :pt="attrs.pt"
       @change="handleInput"
     />
   </div>

--- a/src/formkit/PrimeListbox.vue
+++ b/src/formkit/PrimeListbox.vue
@@ -36,6 +36,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :filter-match-mode="attrs.filterMatchMode"
       :auto-option-focus="attrs.autoOptionFocus ?? true"
       :select-on-focus="attrs.selectOnFocus ?? false"
+      :pt="attrs.pt"
       @change="handleInput"
     />
   </div>

--- a/src/formkit/PrimeMultiSelect.vue
+++ b/src/formkit/PrimeMultiSelect.vue
@@ -29,6 +29,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :option-label="attrs.optionLabel ?? 'label'"
       :option-value="attrs.optionValue ?? 'value'"
       :filter="attrs.filter ?? false"
+      :pt="attrs.pt"
       @change="handleChange"
     />
   </div>

--- a/src/formkit/PrimePassword.vue
+++ b/src/formkit/PrimePassword.vue
@@ -40,6 +40,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :show-icon="attrs.showIcon ?? 'pi pi-eye'"
       :feedback="context.feedback ?? false"
       :toggle-mask="context.toggleMask ?? false"
+      :pt="attrs.pt"
       @input="handleInput"
       @blur="handleBlur"
     />

--- a/src/formkit/PrimeRadioButton.vue
+++ b/src/formkit/PrimeRadioButton.vue
@@ -22,6 +22,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
         :value="option.value"
         :input-style="attrs.style"
         :input-class="styleClass"
+        :pt="attrs.pt"
         @click="handleChange"
         @change="handleChange"
       />

--- a/src/formkit/PrimeRating.vue
+++ b/src/formkit/PrimeRating.vue
@@ -30,6 +30,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :on-icon="attrs.onIcon ?? 'pi pi-star-fill'"
       :off-icon="attrs.offIcon ?? 'pi pi-star'"
       :cancel-icon="attrs.cancelIcon ?? 'pi pi-ban'"
+      :pt="attrs.pt"
       @change="handleInput"
     />
   </div>

--- a/src/formkit/PrimeSelectButton.vue
+++ b/src/formkit/PrimeSelectButton.vue
@@ -32,6 +32,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :multiple="attrs.multiple ?? false"
       :unselectable="attrs.unselectable ?? true"
       :data-key="attrs.dataKey"
+      :pt="attrs.pt"
       @change="handleChange"
     />
   </div>

--- a/src/formkit/PrimeSlider.vue
+++ b/src/formkit/PrimeSlider.vue
@@ -30,6 +30,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :step="attrs.step ?? undefined"
       :range="attrs.range ?? false"
       :orientation="attrs.orientation ?? 'horizontal'"
+      :pt="attrs.pt"
       @change="handleInput"
     />
   </div>

--- a/src/formkit/PrimeTextarea.vue
+++ b/src/formkit/PrimeTextarea.vue
@@ -30,6 +30,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :aria-labelledby="attrs.ariaLabelledby"
       :placeholder="attrs.placeholder"
       :rows="context.rows ?? 3"
+      :pt="attrs.pt"
       @input="handleInput"
       @blur="handleBlur"
     />

--- a/src/formkit/PrimeToggleButton.vue
+++ b/src/formkit/PrimeToggleButton.vue
@@ -29,6 +29,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :on-icon="attrs.onIcon ?? 'pi pi-check'"
       :off-icon="attrs.offIcon ?? 'pi pi-times'"
       :icon-pos="attrs.iconPos ?? 'left'"
+      :pt="attrs.pt"
       @change="handleChange"
     />
   </div>

--- a/src/formkit/PrimeTriStateCheckbox.vue
+++ b/src/formkit/PrimeTriStateCheckbox.vue
@@ -26,6 +26,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       :tabindex="attrs.tabindex"
       :aria-label="attrs.ariaLabel"
       :aria-labelledby="attrs.ariaLabelledby"
+      :pt="attrs.pt"
       @click="handleChange"
     />
     <span v-if="context.attrs.labelRight" class="formkit-prime-right">{{ context.attrs.labelRight }}</span>


### PR DESCRIPTION
PrimeVue has a passthrough prop called `pt` on all components to pass attributes to the DOM elements that PrimeVue renders. Adding this functionality to `formkit-primevue` makes forms more customisable.