### PR TITLE
Fix reactivity of attrs

### DIFF
--- a/src/formkit/PrimeAutoComplete.vue
+++ b/src/formkit/PrimeAutoComplete.vue
@@ -4,19 +4,19 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 const suggestions = ref([])
 
 function search(event) {
-  suggestions.value = attrs.complete(event.query)
+  suggestions.value = attrs.value.complete(event.query)
 }
 
 function handleInput(e: any) {
   context?.node.input(props.context?._value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeCalendar.vue
+++ b/src/formkit/PrimeCalendar.vue
@@ -4,7 +4,7 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(context?._value)
@@ -14,7 +14,7 @@ function handleSelect(e: any) {
   context?.node.input(e)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeCheckbox.vue
+++ b/src/formkit/PrimeCheckbox.vue
@@ -4,13 +4,13 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(props.context?._value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeChips.vue
+++ b/src/formkit/PrimeChips.vue
@@ -4,12 +4,12 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(props.context?._value)
 }
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeColorPicker.vue
+++ b/src/formkit/PrimeColorPicker.vue
@@ -4,7 +4,7 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleChange(e: any) {
   context?.node.input(props.context?._value)

--- a/src/formkit/PrimeDropdown.vue
+++ b/src/formkit/PrimeDropdown.vue
@@ -4,7 +4,7 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleBlur(e: any) {
   context?.handlers.blur(e.value)
@@ -12,7 +12,7 @@ function handleBlur(e: any) {
 function handleInput(e: any) {
   context?.node.input(e.value)
 }
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeEditor.vue
+++ b/src/formkit/PrimeEditor.vue
@@ -6,7 +6,7 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(e.htmlValue)
@@ -17,7 +17,7 @@ function handleSelection(e: EditorSelectionChangeEvent) {
     context?.handlers.blur(e.htmlValue)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeInputMask.vue
+++ b/src/formkit/PrimeInputMask.vue
@@ -4,13 +4,13 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(props.context?._value)
   context?.handlers.blur(props.context?._value)
 }
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeInputNumber.vue
+++ b/src/formkit/PrimeInputNumber.vue
@@ -4,7 +4,7 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleBlur(e: any) {
   context?.handlers.blur(e.value)
@@ -13,7 +13,7 @@ function handleBlur(e: any) {
 function handleInput(e: any) {
   context?.node.input(e.value)
 }
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeInputSwitch.vue
+++ b/src/formkit/PrimeInputSwitch.vue
@@ -4,12 +4,12 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(props.context?._value)
 }
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeInputText.vue
+++ b/src/formkit/PrimeInputText.vue
@@ -4,7 +4,7 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function hasLeftIcon() {
   return context?.iconLeft && context?.iconLeft.length > 0
@@ -31,7 +31,7 @@ function handleInput(e: any) {
   context?.node.input(e.target.value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeKnob.vue
+++ b/src/formkit/PrimeKnob.vue
@@ -4,7 +4,7 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(e)
@@ -15,7 +15,7 @@ function updateValue(n: number) {
   context?.node.input(n)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeListbox.vue
+++ b/src/formkit/PrimeListbox.vue
@@ -4,13 +4,13 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(props.context?._value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeMultiSelect.vue
+++ b/src/formkit/PrimeMultiSelect.vue
@@ -4,13 +4,13 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleChange(e: any) {
   context?.node.input(props.context?._value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimePassword.vue
+++ b/src/formkit/PrimePassword.vue
@@ -4,7 +4,7 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleBlur(e: any) {
   context?.handlers.blur(e.target.value)
@@ -14,7 +14,7 @@ function handleInput(e: any) {
   context?.node.input(e.target.value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeRadioButton.vue
+++ b/src/formkit/PrimeRadioButton.vue
@@ -4,13 +4,13 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleChange(e: any) {
   context?.node.input(props.context?._value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeRating.vue
+++ b/src/formkit/PrimeRating.vue
@@ -4,13 +4,13 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(props.context?._value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeSelectButton.vue
+++ b/src/formkit/PrimeSelectButton.vue
@@ -4,13 +4,13 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleChange(e: any) {
   context?.node.input(props.context?._value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeSlider.vue
+++ b/src/formkit/PrimeSlider.vue
@@ -4,13 +4,13 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleInput(e: any) {
   context?.node.input(e)
   context?.handlers.blur(e)
 }
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeTextarea.vue
+++ b/src/formkit/PrimeTextarea.vue
@@ -4,7 +4,7 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleBlur(e: any) {
   context?.handlers.blur(e.target.value)
@@ -13,7 +13,7 @@ function handleBlur(e: any) {
 function handleInput(e: any) {
   context?.node.input(e.target.value)
 }
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeToggleButton.vue
+++ b/src/formkit/PrimeToggleButton.vue
@@ -4,12 +4,12 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleChange(e: any) {
   context?.node.input(props.context?._value)
 }
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>

--- a/src/formkit/PrimeTriStateCheckbox.vue
+++ b/src/formkit/PrimeTriStateCheckbox.vue
@@ -4,13 +4,13 @@ const props = defineProps({
 })
 
 const context = props.context
-const attrs = context?.attrs
+const attrs = computed(() => context?.attrs)
 
 function handleChange(e: any) {
   context?.node.input(props.context?._value)
 }
 
-const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs?.class} p-invalid` : attrs?.class)
+const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
 <template>


### PR DESCRIPTION
In all components, the `context.attrs` property is accessed without `computed`. This breaks Vue's reactivity, because `attrs` itself isn't reactive, only `props` and `context`. This PR adds `computed` to `attrs` and adds `.value` calls where necessary.

I found this issue by trying to change `PrimeDropdown`'s options after initially mounting it. FormKit passes the correct values to `PrimeDropdown`, but that component fails to update the props passed to `Dropdown`.