### PR TITLE
feat(PrimeCalendar): Support clearing value

### DIFF
--- a/src/formkit/PrimeCalendar.vue
+++ b/src/formkit/PrimeCalendar.vue
@@ -20,6 +20,10 @@ function handleBlur(e: CalendarBlurEvent) {
   context?.handlers.blur(e.value)
 }
 
+function handleClearClick() {
+  context?.node.input(null)
+}
+
 const styleClass = computed(() => (context?.state.validationVisible && !context?.state.valid) ? `${attrs.value?.class} p-invalid` : attrs.value?.class)
 </script>
 
@@ -82,6 +86,7 @@ const styleClass = computed(() => (context?.state.validationVisible && !context?
       @date-select="handleSelect"
       @input="handleInput"
       @blur="handleBlur"
+      @clear-click="handleClearClick"
     />
   </div>
 </template>


### PR DESCRIPTION
i need some way to clear the date value

the `showButtonBar` option reveals a button for clearing the date value but when pressed it doesn't change the actual form value. i locally confirmed this solves my use case