### PR TITLE
replace deprecated sass built-in functions

### DIFF
--- a/src/sass/formkit-primevue.scss
+++ b/src/sass/formkit-primevue.scss
@@ -1,4 +1,5 @@
 @use 'sass:math';
+@use 'sass:map';
 
 $gutter-width: 0.5rem;
 
@@ -12,7 +13,7 @@ $grid-breakpoints: (
 ) !default;
 
 @function breakpoint-min($name, $breakpoints: $grid-breakpoints) {
-  $min: map-get($breakpoints, $name);
+  $min: map.get($breakpoints, $name);
   @return if($min != 0, $min, null);
 }
 
@@ -303,7 +304,7 @@ $grid-breakpoints: (
   }
   @for $i from 1 through 12 {
     .col-#{$i} {
-      width: percentage(math.div($i, 12));
+      width: math.percentage(math.div($i, 12));
     }
   }
 }


### PR DESCRIPTION
Replaces `percentage` with `math.percentage` and `map-get` with `map.get` in `formkit-primevue.scss` as Sass has deprecated global built-in functions as of version 1.80.0